### PR TITLE
feat: 增加多线程翻译，修改错误翻译配置

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ djano-admin makemessages -l ${YOUR_LANGUAGE}
 
 ### 3.机器翻译词条
 ```bash
-python jinx.py translator -p ${YOUR_PO_FILE} -o {YOUR_OFFICIAL_DICT_DIR}
+python jinx.py translator -p ${YOUR_PO_FILE} -o ${YOUR_OFFICIAL_DICT_DIR}
 ```
 - YOUR_PO_FILE: 你的po文件目录, 也支持填入locale目录, 会自动寻找locale目录下的对应语言po文件
 - YOUR_OFFICIAL_DICT_DIR: 你的官方词典目录, JSON格式, 用于翻译时的参考, 最大匹配翻译, 参考[官方词典official_dict](official_dict.template.json)
@@ -153,7 +153,7 @@ exclude_files = [
 [marker.translation_func]
 # 默认的翻译函数配置
 ## 默认的翻译函数
-default = "ugettext_lazy"
+default = "gettext_lazy"
 ## 翻译函数别名
 alias = "_"
 

--- a/common/config.py
+++ b/common/config.py
@@ -87,7 +87,7 @@ config_util = ConfigUtil(config_path=_config_path)
 
 language = LanguageConfig(
     current=config_util.get("language.current", LanguageEnum.Chinese),
-    dest=config_util.get("language.target", LanguageEnum.English),
+    dest=config_util.get("language.dest", LanguageEnum.English),
 )
 
 # 只允许其他模块导入__all__中的变量

--- a/jinx.template.toml
+++ b/jinx.template.toml
@@ -34,7 +34,7 @@ exclude_files = [
 [marker.translation_func]
 # 默认的翻译函数配置
 ## 默认的翻译函数
-default = "ugettext_lazy"
+default = "gettext_lazy"
 ## 翻译函数别名
 alias = "_"
 


### PR DESCRIPTION
1.  使用多线程调用翻译接口，翻译速度提高1个数量级
2.  配置模板中目标翻译语言为dest，但代码中读取的是target，修改代码使其读取正确配置
3. 配置模板中marker的默认翻译函数为ugettext_lazy，但是该函数在django3开始被废弃，dango4开始不在有此函数。改为更现代的gettext_lazy